### PR TITLE
Fix multi-question input handling and clean up gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,26 +4,7 @@ logs
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
-<<<<<<< HEAD
 pnpm-debug.log*
-lerna-debug.log*
-
-node_modules
-dist
-dist-ssr
-*.local
-
-# Editor directories and files
-.vscode/*
-!.vscode/extensions.json
-.idea
-.DS_Store
-*.suo
-*.ntvs*
-*.njsproj
-*.sln
-*.sw?
-=======
 lerna-debug.log*
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
@@ -101,6 +82,8 @@ out
 # Nuxt.js build / generate output
 .nuxt
 dist
+dist-ssr
+*.local
 
 # Gatsby files
 .cache/
@@ -157,4 +140,3 @@ dist
 # Vite logs files
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
->>>>>>> 7e20a5676cec9d8f17257dd65c5b32d50d529359

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,34 +1,45 @@
 import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
 import './App.css'
 
 function App() {
-  const [count, setCount] = useState(0)
+  const [questions, setQuestions] = useState([
+    { text: 'Pregunta 1', answers: ['', ''] },
+    { text: 'Pregunta 2', answers: ['', ''] },
+  ])
+
+  const handleAnswerChange = (qIndex, aIndex, value) => {
+    setQuestions(prev =>
+      prev.map((q, idx) =>
+        idx === qIndex
+          ? {
+              ...q,
+              answers: q.answers.map((ans, j) => (j === aIndex ? value : ans)),
+            }
+          : q
+      )
+    )
+  }
 
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    <div>
+      {questions.map((q, qIdx) => (
+        <div key={qIdx}>
+          <h2>{q.text}</h2>
+          {q.answers.map((ans, aIdx) => (
+            <div key={aIdx}>
+              <label>
+                Respuesta {aIdx + 1}: {' '}
+                <input
+                  type="text"
+                  value={ans}
+                  onChange={e => handleAnswerChange(qIdx, aIdx, e.target.value)}
+                />
+              </label>
+            </div>
+          ))}
+        </div>
+      ))}
+    </div>
   )
 }
 


### PR DESCRIPTION
## Summary
- Resolve merge conflict leftovers in .gitignore
- Add form state management so each answer field updates the correct question

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0d7260f48832591d0232eddee5c3f