### PR TITLE
refactor: replace unicode property regex in slug

### DIFF
--- a/src/SOPWizard.jsx
+++ b/src/SOPWizard.jsx
@@ -158,7 +158,7 @@ const slug = (s) =>
   s
     .toLowerCase()
     .normalize("NFD")
-    .replace(/\p{Diacritic}/gu, "")
+    .replace(/[\u0300-\u036f]/g, "")
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/(^-|-$)/g, "");
 


### PR DESCRIPTION
## Summary
- replace Unicode property regex in slug helper with explicit range for broader compatibility

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden retrieving framer-motion)*

------
https://chatgpt.com/codex/tasks/task_e_68b1cc0a6cf08325be5f11b078846cec